### PR TITLE
Feature/supports service account

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/mackerelio/mackerel-plugin-gcp-compute-engine/lib"
+import mpgcpcomputeengine "github.com/mackerelio/mackerel-plugin-gcp-compute-engine/lib"
 
 func main() {
 	mpgcpcomputeengine.Do()


### PR DESCRIPTION
Typically GCE instances has a service account.
So if the instance's service account is granted `monitoring.read` scope, this plugin don't have to require `-api-key` option.

This patch makes that this plugin use service account if not `-api-key` option is specified.