### PR TITLE
adjust metric value by ratio

### DIFF
--- a/lib/gcp-compute-engine.go
+++ b/lib/gcp-compute-engine.go
@@ -59,7 +59,7 @@ var graphdef = map[string]mp.Graphs{
 		Label: "CPU Utilization",
 		Unit:  "percentage",
 		Metrics: []mp.Metrics{
-			{Name: "utilization", Label: "Utilization"},
+			{Name: "utilization", Label: "Utilization", Scale: 100},
 		},
 	},
 	"Disk.BytesCount": mp.Graphs{
@@ -147,35 +147,24 @@ func (p ComputeEnginePlugin) FetchMetrics() (map[string]interface{}, error) {
 	listCall := p.MonitoringService.Projects.TimeSeries.List(p.Project)
 
 	stat := map[string]interface{}{}
-	for metricName, ratio := range map[string]uint64{
-		"/firewall/dropped_bytes_count":            1,
-		"/firewall/dropped_packets_count":          1,
-		"/instance/cpu/utilization":                100,
-		"/instance/disk/read_bytes_count":          1,
-		"/instance/disk/read_ops_count":            1,
-		"/instance/disk/write_bytes_count":         1,
-		"/instance/disk/write_ops_count":           1,
-		"/instance/network/received_bytes_count":   1,
-		"/instance/network/received_packets_count": 1,
-		"/instance/network/sent_bytes_count":       1,
-		"/instance/network/sent_packets_count":     1,
+	for _, metricName := range []string{
+		"/firewall/dropped_bytes_count",
+		"/firewall/dropped_packets_count",
+		"/instance/cpu/utilization",
+		"/instance/disk/read_bytes_count",
+		"/instance/disk/read_ops_count",
+		"/instance/disk/write_bytes_count",
+		"/instance/disk/write_ops_count",
+		"/instance/network/received_bytes_count",
+		"/instance/network/received_packets_count",
+		"/instance/network/sent_bytes_count",
+		"/instance/network/sent_packets_count",
 	} {
 		value, err := getLatestValue(listCall, mkFilter(computeDomain, metricName, p.InstanceName), formattedStart, formattedEnd, p.Option)
 		if err != nil {
 			log.Printf("Failed to fetch a datapoint for %s: %s\n", metricName, err)
 			continue
 		}
-
-		// adjust metric value by ratio
-		if ratio != 1 {
-			switch v := value.(type) {
-			case uint64:
-				value = v * ratio
-			case float64:
-				value = v * float64(ratio)
-			}
-		}
-
 		splited := strings.Split(metricName, "/")
 		stat[splited[len(splited)-1]] = value
 	}


### PR DESCRIPTION
`/instance/cpu/utilization` is expressed as ratio by 1. (e.g. `0.012`)
but Mackerel's percentage unit needs normally percentage value (e.g. `1.2`).
so it should be 100 times value.